### PR TITLE
[utility] Allows custom secret for webhook validation

### DIFF
--- a/src/main/java/com/razorpay/RazorpayClient.java
+++ b/src/main/java/com/razorpay/RazorpayClient.java
@@ -13,7 +13,6 @@ public class RazorpayClient {
   public CardClient Cards;
   public CustomerClient Customers;
   public TransferClient Transfers;
-  public Utils Utility;
 
   public RazorpayClient(String key, String secret) throws RazorpayException {
     this(key, secret, false);
@@ -29,7 +28,6 @@ public class RazorpayClient {
     Cards = new CardClient(auth);
     Customers = new CustomerClient(auth);
     Transfers = new TransferClient(auth);
-    Utility = new Utils(key, secret);
   }
 
   public RazorpayClient addHeaders(Map<String, String> headers) {

--- a/src/main/java/com/razorpay/Utils.java
+++ b/src/main/java/com/razorpay/Utils.java
@@ -22,25 +22,26 @@ public class Utils {
     String orderId = attributes.getString("razorpay_order_id");
     String paymentId = attributes.getString("razorpay_payment_id");
     String payload = orderId + '|' + paymentId;
-    return verifySignature(payload, expectedSignature);
+    String apiSecret = this.secret;
+    return verifySignature(payload, expectedSignature, apiSecret);
   }
 
-  public boolean verifyWebhookSignature(String payload, String expectedSignature)
+  public boolean verifyWebhookSignature(String payload, String expectedSignature, String webhookSecret)
       throws RazorpayException {
-    return verifySignature(payload, expectedSignature);
+    return verifySignature(payload, expectedSignature, webhookSecret);
   }
 
-  public boolean verifySignature(String payload, String expectedSignature)
+  public boolean verifySignature(String payload, String expectedSignature, String secret)
       throws RazorpayException {
-    String actualSignature = getHash(payload);
+    String actualSignature = getHash(payload, secret);
     return isEqual(actualSignature.getBytes(), expectedSignature.getBytes());
   }
 
-  public String getHash(String payload) throws RazorpayException {
+  public String getHash(String payload, String secret) throws RazorpayException {
     Mac sha256_HMAC;
     try {
       sha256_HMAC = Mac.getInstance("HmacSHA256");
-      SecretKeySpec secret_key = new SecretKeySpec(this.secret.getBytes("UTF-8"), "HmacSHA256");
+      SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes("UTF-8"), "HmacSHA256");
       sha256_HMAC.init(secret_key);
       byte[] hash = sha256_HMAC.doFinal(payload.getBytes());
       return new String(Hex.encodeHex(hash));

--- a/src/main/java/com/razorpay/Utils.java
+++ b/src/main/java/com/razorpay/Utils.java
@@ -12,6 +12,10 @@ public class Utils {
 
   private String secret;
 
+  public Utils() {
+
+  }
+
   public Utils(String key, String secret) {
     this.key = key;
     this.secret = secret;
@@ -22,12 +26,11 @@ public class Utils {
     String orderId = attributes.getString("razorpay_order_id");
     String paymentId = attributes.getString("razorpay_payment_id");
     String payload = orderId + '|' + paymentId;
-    String apiSecret = this.secret;
-    return verifySignature(payload, expectedSignature, apiSecret);
+    return verifySignature(payload, expectedSignature, this.secret);
   }
 
-  public boolean verifyWebhookSignature(String payload, String expectedSignature, String webhookSecret)
-      throws RazorpayException {
+  public boolean verifyWebhookSignature(String payload, String expectedSignature,
+      String webhookSecret) throws RazorpayException {
     return verifySignature(payload, expectedSignature, webhookSecret);
   }
 

--- a/src/main/java/com/razorpay/Utils.java
+++ b/src/main/java/com/razorpay/Utils.java
@@ -8,39 +8,27 @@ import org.json.JSONObject;
 
 public class Utils {
 
-  private String key;
-
-  private String apiSecret;
-
-  public Utils() {
-
-  }
-
-  public Utils(String key, String secret) {
-    this.key = key;
-    this.apiSecret = secret;
-  }
-
-  public boolean verifyPaymentSignature(JSONObject attributes) throws RazorpayException {
+  public static boolean verifyPaymentSignature(JSONObject attributes, String apiSecret)
+      throws RazorpayException {
     String expectedSignature = attributes.getString("razorpay_signature");
     String orderId = attributes.getString("razorpay_order_id");
     String paymentId = attributes.getString("razorpay_payment_id");
     String payload = orderId + '|' + paymentId;
-    return verifySignature(payload, expectedSignature, this.apiSecret);
+    return verifySignature(payload, expectedSignature, apiSecret);
   }
 
-  public boolean verifyWebhookSignature(String payload, String expectedSignature,
+  public static boolean verifyWebhookSignature(String payload, String expectedSignature,
       String webhookSecret) throws RazorpayException {
     return verifySignature(payload, expectedSignature, webhookSecret);
   }
 
-  public boolean verifySignature(String payload, String expectedSignature, String secret)
+  public static boolean verifySignature(String payload, String expectedSignature, String secret)
       throws RazorpayException {
     String actualSignature = getHash(payload, secret);
     return isEqual(actualSignature.getBytes(), expectedSignature.getBytes());
   }
 
-  public String getHash(String payload, String secret) throws RazorpayException {
+  public static String getHash(String payload, String secret) throws RazorpayException {
     Mac sha256_HMAC;
     try {
       sha256_HMAC = Mac.getInstance("HmacSHA256");
@@ -61,7 +49,7 @@ public class Utils {
    * @param b
    * @return boolean
    */
-  private boolean isEqual(byte[] a, byte[] b) {
+  private static boolean isEqual(byte[] a, byte[] b) {
     if (a.length != b.length) {
       return false;
     }

--- a/src/main/java/com/razorpay/Utils.java
+++ b/src/main/java/com/razorpay/Utils.java
@@ -10,7 +10,7 @@ public class Utils {
 
   private String key;
 
-  private String secret;
+  private String apiSecret;
 
   public Utils() {
 
@@ -18,7 +18,7 @@ public class Utils {
 
   public Utils(String key, String secret) {
     this.key = key;
-    this.secret = secret;
+    this.apiSecret = secret;
   }
 
   public boolean verifyPaymentSignature(JSONObject attributes) throws RazorpayException {
@@ -26,7 +26,7 @@ public class Utils {
     String orderId = attributes.getString("razorpay_order_id");
     String paymentId = attributes.getString("razorpay_payment_id");
     String payload = orderId + '|' + paymentId;
-    return verifySignature(payload, expectedSignature, this.secret);
+    return verifySignature(payload, expectedSignature, this.apiSecret);
   }
 
   public boolean verifyWebhookSignature(String payload, String expectedSignature,


### PR DESCRIPTION
 - Webhook validation currently uses merchant API secret by default for signature generation.
 - Method now accepts secret as input, so a different secret can be used for webhooks