### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ List<Payment> payments = razorpayClient.Orders.fetchPayments("order_id");
 You can use the Utils class to verify the signature received in response to a payment made using Orders API
 ```java
 JSONObject paymentResponse = new JSONObject();
-options.put("razorpay_order_id", "<order_id>");
-options.put("razorpay_payment_id", "<payment_id>");
-options.put("razorpay_signature", "<signature>");
+paymentResponse.put("razorpay_order_id", "<order_id>");
+paymentResponse.put("razorpay_payment_id", "<payment_id>");
+paymentResponse.put("razorpay_signature", "<signature>");
 Utils.verifyPaymentSignature(paymentResponse, "<secret_key>");
 ```
 You can also verify the signature of the received webhook:


### PR DESCRIPTION
In verification Phase , in lines (167-169 ) "options" is  used as an JSON Object to put values instead of "paymentResponse" which is wrong.