### PR TITLE
fix razorapy java-sdk currecny bugs

### DIFF
--- a/src/main/java/com/razorpay/AddonClient.java
+++ b/src/main/java/com/razorpay/AddonClient.java
@@ -2,8 +2,8 @@ package com.razorpay;
 
 public class AddonClient extends ApiClient {
 
-  AddonClient(String auth) {
-    super(auth);
+  AddonClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   // To create an Addon, use the createAddon method of SubscriptionClient

--- a/src/main/java/com/razorpay/ApiClient.java
+++ b/src/main/java/com/razorpay/ApiClient.java
@@ -27,38 +27,41 @@ class ApiClient {
 
   private final int STATUS_MULTIPLE_CHOICE = 300;
 
-  ApiClient(String auth) {
+  String clientKey;
+
+  ApiClient(String auth, String clientKey) {
     this.auth = auth;
+    this.clientKey = clientKey;
   }
 
   public <T extends Entity> T get(String path, JSONObject requestObject) throws RazorpayException {
-    Response response = ApiUtils.getRequest(path, requestObject, auth);
+    Response response = ApiUtils.getRequest(path, requestObject, auth, clientKey);
     return processResponse(response);
   }
 
   public <T extends Entity> T post(String path, JSONObject requestObject) throws RazorpayException {
-    Response response = ApiUtils.postRequest(path, requestObject, auth);
+    Response response = ApiUtils.postRequest(path, requestObject, auth, clientKey);
     return processResponse(response);
   }
 
   public <T extends Entity> T put(String path, JSONObject requestObject) throws RazorpayException {
-    Response response = ApiUtils.putRequest(path, requestObject, auth);
+    Response response = ApiUtils.putRequest(path, requestObject, auth, clientKey);
     return processResponse(response);
   }
 
   public <T extends Entity> T patch(String path, JSONObject requestObject) throws RazorpayException {
-    Response response = ApiUtils.patchRequest(path, requestObject, auth);
+    Response response = ApiUtils.patchRequest(path, requestObject, auth, clientKey);
     return processResponse(response);
   }
 
   public void delete(String path, JSONObject requestObject) throws RazorpayException {
-    Response response = ApiUtils.deleteRequest(path, requestObject, auth);
+    Response response = ApiUtils.deleteRequest(path, requestObject, auth, clientKey);
     processDeleteResponse(response);
   }
 
   <T extends Entity> ArrayList<T> getCollection(String path, JSONObject requestObject)
       throws RazorpayException {
-    Response response = ApiUtils.getRequest(path, requestObject, auth);
+    Response response = ApiUtils.getRequest(path, requestObject, auth, clientKey);
     return processCollectionResponse(response);
   }
 

--- a/src/main/java/com/razorpay/CardClient.java
+++ b/src/main/java/com/razorpay/CardClient.java
@@ -2,8 +2,8 @@ package com.razorpay;
 
 public class CardClient extends ApiClient {
 
-  CardClient(String auth) {
-    super(auth);
+  CardClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Card fetch(String id) throws RazorpayException {

--- a/src/main/java/com/razorpay/CustomerClient.java
+++ b/src/main/java/com/razorpay/CustomerClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class CustomerClient extends ApiClient {
 
-  CustomerClient(String auth) {
-    super(auth);
+  CustomerClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Customer create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/InvoiceClient.java
+++ b/src/main/java/com/razorpay/InvoiceClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class InvoiceClient extends ApiClient {
 
-  InvoiceClient(String auth) {
-    super(auth);
+  InvoiceClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Invoice create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/OrderClient.java
+++ b/src/main/java/com/razorpay/OrderClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class OrderClient extends ApiClient {
 
-  OrderClient(String auth) {
-    super(auth);
+  OrderClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Order create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/PaymentClient.java
+++ b/src/main/java/com/razorpay/PaymentClient.java
@@ -10,9 +10,9 @@ public class PaymentClient extends ApiClient {
 
   private RefundClient refundClient;
 
-  PaymentClient(String auth) {
-    super(auth);
-    refundClient = new RefundClient(auth);
+  PaymentClient(String auth, String clientKey) {
+    super(auth, clientKey);
+    refundClient = new RefundClient(auth, clientKey);
   }
 
   public Payment fetch(String id) throws RazorpayException {
@@ -65,7 +65,7 @@ public class PaymentClient extends ApiClient {
 
   public List<Transfer> transfer(String id, JSONObject request) throws RazorpayException {
     Response response =
-        ApiUtils.postRequest(String.format(Constants.PAYMENT_TRANSFER_CREATE, id), request, auth);
+        ApiUtils.postRequest(String.format(Constants.PAYMENT_TRANSFER_CREATE, id), request, auth, clientKey);
     return processCollectionResponse(response);
   }
 

--- a/src/main/java/com/razorpay/PlanClient.java
+++ b/src/main/java/com/razorpay/PlanClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class PlanClient extends ApiClient {
 
-    PlanClient(String auth) {
-        super(auth);
+    PlanClient(String auth, String clientKey) {
+        super(auth, clientKey);
     }
 
     public Plan create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/RazorpayClient.java
+++ b/src/main/java/com/razorpay/RazorpayClient.java
@@ -1,6 +1,7 @@
 package com.razorpay;
 
 import java.util.Map;
+import java.util.UUID;
 
 import okhttp3.Credentials;
 
@@ -18,6 +19,8 @@ public class RazorpayClient {
   public PlanClient Plans;
   public VirtualAccountClient VirtualAccounts;
 
+  private String clientKey = UUID.randomUUID().toString();
+
   public RazorpayClient(String key, String secret) throws RazorpayException {
     this(key, secret, false);
   }
@@ -25,21 +28,21 @@ public class RazorpayClient {
   public RazorpayClient(String key, String secret, Boolean enableLogging) throws RazorpayException {
     ApiUtils.createHttpClientInstance(enableLogging);
     String auth = Credentials.basic(key, secret);
-    Payments = new PaymentClient(auth);
-    Refunds = new RefundClient(auth);
-    Orders = new OrderClient(auth);
-    Invoices = new InvoiceClient(auth);
-    Cards = new CardClient(auth);
-    Customers = new CustomerClient(auth);
-    Transfers = new TransferClient(auth);
-    Subscriptions = new SubscriptionClient(auth);
-    Addons = new AddonClient(auth);
-    Plans = new PlanClient(auth);
-    VirtualAccounts = new VirtualAccountClient(auth);
+    Payments = new PaymentClient(auth, clientKey);
+    Refunds = new RefundClient(auth, clientKey);
+    Orders = new OrderClient(auth, clientKey);
+    Invoices = new InvoiceClient(auth, clientKey);
+    Cards = new CardClient(auth, clientKey);
+    Customers = new CustomerClient(auth, clientKey);
+    Transfers = new TransferClient(auth, clientKey);
+    Subscriptions = new SubscriptionClient(auth, clientKey);
+    Addons = new AddonClient(auth, clientKey);
+    Plans = new PlanClient(auth, clientKey);
+    VirtualAccounts = new VirtualAccountClient(auth, clientKey);
   }
 
   public RazorpayClient addHeaders(Map<String, String> headers) {
-    ApiUtils.addHeaders(headers);
+    ApiUtils.addHeaders(clientKey, headers);
     return this;
   }
 }

--- a/src/main/java/com/razorpay/RefundClient.java
+++ b/src/main/java/com/razorpay/RefundClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class RefundClient extends ApiClient {
 
-  RefundClient(String auth) {
-    super(auth);
+  RefundClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Refund create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/SubscriptionClient.java
+++ b/src/main/java/com/razorpay/SubscriptionClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class SubscriptionClient extends ApiClient {
 
-  SubscriptionClient(String auth) {
-    super(auth);
+  SubscriptionClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Subscription create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/TransferClient.java
+++ b/src/main/java/com/razorpay/TransferClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class TransferClient extends ApiClient {
 
-  TransferClient(String auth) {
-    super(auth);
+  TransferClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public Transfer create(JSONObject request) throws RazorpayException {

--- a/src/main/java/com/razorpay/VirtualAccountClient.java
+++ b/src/main/java/com/razorpay/VirtualAccountClient.java
@@ -6,8 +6,8 @@ import org.json.JSONObject;
 
 public class VirtualAccountClient extends ApiClient {
 
-  VirtualAccountClient(String auth) {
-    super(auth);
+  VirtualAccountClient(String auth, String clientKey) {
+    super(auth, clientKey);
   }
 
   public VirtualAccount create(JSONObject request) throws RazorpayException {


### PR DESCRIPTION
fix razorapy multi RazorpayClient instance and concurrency caused headers mis-match bug.

This bug will be re-produced if user initiate multi RazorapyClient, each client belongs to different sub-merchant, and has set different MID for each RazorapyClient