### PR TITLE
Adding methods to RazorpayClient to allow custom timeout duration

### DIFF
--- a/src/main/java/com/razorpay/ApiUtils.java
+++ b/src/main/java/com/razorpay/ApiUtils.java
@@ -31,7 +31,7 @@ class ApiUtils {
 
   private static String version = null;
 
-  static void createHttpClientInstance(boolean enableLogging) throws RazorpayException {
+  static void createHttpClientInstance(boolean enableLogging, int timeout) throws RazorpayException {
     if (client == null) {
       HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
       if (enableLogging) {
@@ -42,8 +42,8 @@ class ApiUtils {
       
       try {
         client = new OkHttpClient.Builder()
-                                 .readTimeout(60, TimeUnit.SECONDS)
-                                 .writeTimeout(60, TimeUnit.SECONDS)
+                                 .readTimeout(timeout, TimeUnit.SECONDS)
+                                 .writeTimeout(timeout, TimeUnit.SECONDS)
                                  .addInterceptor(loggingInterceptor)
                                  .sslSocketFactory(new CustomTLSSocketFactory(), createDefaultTrustManager())
                                  .build();
@@ -165,7 +165,7 @@ class ApiUtils {
   static void addHeaders(Map<String, String> header) {
     headers.putAll(header);
   }
-  
+
   private static X509TrustManager createDefaultTrustManager() throws NoSuchAlgorithmException, KeyStoreException {
     TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
     trustManagerFactory.init((KeyStore) null);

--- a/src/main/java/com/razorpay/RazorpayClient.java
+++ b/src/main/java/com/razorpay/RazorpayClient.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import okhttp3.Credentials;
 
 public class RazorpayClient {
+  private static final int DEFAULT_TIMEOUT_DURATION_IN_SECONDS = 60;
 
   public PaymentClient Payments;
   public RefundClient Refunds;
@@ -19,11 +20,19 @@ public class RazorpayClient {
   public VirtualAccountClient VirtualAccounts;
 
   public RazorpayClient(String key, String secret) throws RazorpayException {
-    this(key, secret, false);
+    this(key, secret, false, DEFAULT_TIMEOUT_DURATION_IN_SECONDS);
   }
 
   public RazorpayClient(String key, String secret, Boolean enableLogging) throws RazorpayException {
-    ApiUtils.createHttpClientInstance(enableLogging);
+    this(key, secret, enableLogging, DEFAULT_TIMEOUT_DURATION_IN_SECONDS);
+  }
+
+  public RazorpayClient(String key, String secret, int timeoutDurationInSeconds) throws RazorpayException {
+    this(key, secret, false, timeoutDurationInSeconds);
+  }
+
+  public RazorpayClient(String key, String secret, Boolean enableLogging, Integer timeout) throws RazorpayException {
+    ApiUtils.createHttpClientInstance(enableLogging, timeout);
     String auth = Credentials.basic(key, secret);
     Payments = new PaymentClient(auth);
     Refunds = new RefundClient(auth);


### PR DESCRIPTION
## Summary
- At Coursera we have a 30s cutoff on all user facing calls and would like to keep all our external calls within a given time period to ensure we are able to better communicate error messages to the user
- This is a result of last month's outage where RazorPay was under a major DDoS attack which significantly slowed down the razorpay service and caused a bad user experience for everyone trying to check out
- Keeping the two above points in my mind, I propose we allow users of the `RazorpayClient` to be able to pass in a custom timeout duration (less or more than 60s which is default) and deal with slow responses better

## Change Log
- Added a constructor to `RazorpayClient` to create with a custom timeout duration otherwise use default

## Consideration
- Discuss if we would like to impose a minimum timeout period

## Testing
- There are currently no Unit tests in the library that have to be modified
- Created a local tag and used in sandbox environment at Coursera and works as expected