### PR TITLE
remove entity from delete

### DIFF
--- a/src/main/java/com/razorpay/AddonClient.java
+++ b/src/main/java/com/razorpay/AddonClient.java
@@ -32,7 +32,7 @@ public class AddonClient extends ApiClient {
       return getCollection(Constants.ADDON_LIST, request);
     }
 
-  public void delete(String id) throws RazorpayException {
-    delete(String.format(Constants.ADDON_DELETE, id), null);
+  public JSONObject delete(String id) throws RazorpayException {
+    return delete(String.format(Constants.ADDON_DELETE, id), null);
   }
 }

--- a/src/main/java/com/razorpay/CustomerClient.java
+++ b/src/main/java/com/razorpay/CustomerClient.java
@@ -47,7 +47,7 @@ public class CustomerClient extends ApiClient {
     return get(String.format(Constants.TOKEN_GET, id, tokenId), null);
   }
 
-  public void deleteToken(String id, String tokenId) throws RazorpayException {
-    delete(String.format(Constants.TOKEN_DELETE, id, tokenId), null);
+  public JSONObject deleteToken(String id, String tokenId) throws RazorpayException {
+    return delete(String.format(Constants.TOKEN_DELETE, id, tokenId), null);
   }
 }

--- a/src/main/java/com/razorpay/EntityNameURLMapping.java
+++ b/src/main/java/com/razorpay/EntityNameURLMapping.java
@@ -3,10 +3,10 @@ package com.razorpay;
 import java.util.Arrays;
 
  /**
- * Enum name is acting as url & entity is denoting Entity class
+ * Enum name is acting as url and entity is denoting Entity class
   * ex: https://api.razorpay.com/v1/invocies
   * getEntityName method will take "invoices" from above mentioned url
-  * & will return "invoice" as entity name as mentioned below in mapping INVOICES("invoice")
+  * and will return "invoice" as entity name as mentioned below in mapping INVOICES("invoice")
  */
 
 public enum EntityNameURLMapping {

--- a/src/main/java/com/razorpay/InvoiceClient.java
+++ b/src/main/java/com/razorpay/InvoiceClient.java
@@ -46,7 +46,7 @@ public class InvoiceClient extends ApiClient {
     return patch(String.format(Constants.INVOICE_GET, id), request);
   }
 
-  public void delete(String id) throws RazorpayException {
-    delete(String.format(Constants.INVOICE_GET, id), null);
+  public JSONObject delete(String id) throws RazorpayException {
+    return delete(String.format(Constants.INVOICE_GET, id), null);
   }
 }

--- a/src/main/java/com/razorpay/ItemClient.java
+++ b/src/main/java/com/razorpay/ItemClient.java
@@ -30,7 +30,7 @@ public class ItemClient extends ApiClient{
 	    return getCollection(Constants.ITEMS, request);
 	}
 
-	public void delete(String id) throws RazorpayException {
-	   delete(String.format(Constants.ITEM, id), null);
+	public JSONObject delete(String id) throws RazorpayException {
+	   return delete(String.format(Constants.ITEM, id), null);
 	}
 }

--- a/src/main/java/com/razorpay/SubscriptionClient.java
+++ b/src/main/java/com/razorpay/SubscriptionClient.java
@@ -54,7 +54,7 @@ public class SubscriptionClient extends ApiClient {
     return post(String.format(Constants.RESUME_SUBSCRIPTION, id), request);
   }
 
-  public Subscription deleteSubscriptionOffer(String subId, String offerId) throws RazorpayException {
+  public JSONObject deleteSubscriptionOffer(String subId, String offerId) throws RazorpayException {
     return delete(String.format(Constants.SUBSCRIPTION_OFFER, subId, offerId), null);
   }
 }

--- a/src/main/java/com/razorpay/TokenClient.java
+++ b/src/main/java/com/razorpay/TokenClient.java
@@ -1,0 +1,2 @@
+package com.razorpay;public class TokenClient {
+}

--- a/src/main/java/com/razorpay/VirtualAccountClient.java
+++ b/src/main/java/com/razorpay/VirtualAccountClient.java
@@ -50,7 +50,7 @@ public class VirtualAccountClient extends ApiClient {
     return post(String.format(Constants.VIRTUAL_ACCOUNT_ALLOWEDPAYERS, id), request);
   }
 
-  public void deleteAllowedPayer(String virtual_id, String payer_id) throws RazorpayException {
-    delete(String.format(Constants.VIRTUAL_ACCOUNT_DELETE_ALLOWEDPAYERS, virtual_id, payer_id), null);
+  public JSONObject deleteAllowedPayer(String virtual_id, String payer_id) throws RazorpayException {
+    return delete(String.format(Constants.VIRTUAL_ACCOUNT_DELETE_ALLOWEDPAYERS, virtual_id, payer_id), null);
   }
 }

--- a/src/test/java/com/razorpay/SubscriptionClientTest.java
+++ b/src/test/java/com/razorpay/SubscriptionClientTest.java
@@ -249,7 +249,7 @@ public class SubscriptionClientTest extends BaseTest {
         String mockedResponseJson = getMockedResponseJson();
         mockResponseFromExternalClient(mockedResponseJson);
         mockResponseHTTPCodeFromExternalClient(200);
-        Subscription subscription = subscriptionClient.deleteSubscriptionOffer(TEST_SUBSCRIPTION_ID, TEST_OFFER);
+        JSONObject subscription = subscriptionClient.deleteSubscriptionOffer(TEST_SUBSCRIPTION_ID, TEST_OFFER);
         assertEquals(TEST_SUBSCRIPTION_ID, subscription.get(SUBSCRIPTION_ID));
         verifySentRequest(false, null, getHost(String.format(Constants.SUBSCRIPTION_OFFER, TEST_SUBSCRIPTION_ID,TEST_OFFER)));
     }


### PR DESCRIPTION
In these delete api it returns empty array and null in response. so i just remove Entity check and change empty array to json response.  

API Reference 
Item module : https://razorpay.com/docs/api/items/#delete-an-item

Subscription offer delete : https://razorpay.com/docs/payments/subscriptions/offers/delete/#delete-an-offer-linked-to-a-subscription-using

Invoice delete : https://razorpay.com/docs/api/invoices/#delete-an-invoice

Customer token delete : https://razorpay.com/docs/api/payments/recurring-payments/emandate/tokens/#23-delete-tokens

virtual Account delete allowed payer : https://razorpay.com/docs/api/payments/smart-collect-tpv/#delete-an-allowed-payer-account