### PR TITLE
registeremandate doc correction

### DIFF
--- a/documents/registerEmandate.md
+++ b/documents/registerEmandate.md
@@ -141,7 +141,7 @@ Invoice invoice = instance.invoices.createRegistrationLink(registrationLinkReque
 
 | Name            | Type    | Description                                                   |
 |-----------------|---------|---------------------------------------------------------------|
-| customer   | object      | Details of the customer to whom the registration link will be sent. |
+| customer   | object  | All keys listed [here](https://razorpay.com/docs/api/recurring-payments/emandate/auto-debit/#121-create-a-registration-link) are supported  |
 | type*  | object | the value is `link`. |
 | amount*   | integer      | The amount to be captured (should be equal to the authorized amount, in paise) |
 | currency*   | string  | The currency of the payment (defaults to INR)  |


### PR DESCRIPTION
[Create an order](https://docs.google.com/spreadsheets/d/1FwFHxOY994oS6jCmPd4ubdC4Itbr5QGaRg24_O6xj4U/edit#gid=0&range=A220) : `auth_type, max_amount, expire_at ,bank acount` should be inside `token`

[Create an registration link](https://docs.google.com/spreadsheets/d/1FwFHxOY994oS6jCmPd4ubdC4Itbr5QGaRg24_O6xj4U/edit#gid=0&range=A222) :  [update](https://github.com/razorpay/razorpay-java/blob/registeremandate_doc_correction/documents/registerEmandate.md?plain=1#L144)