### PR TITLE
workflow stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,17 @@
-name: Publish package to the Maven Central Repository
+name: CI
 on:
-  release:
-    types: [published]
-
+  push:
+    branches:
+      - master
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+  pull_request:
+    branches:
+      - master
 # Jobs
 jobs:
-  codecov-coverage:
+  test:
+    name: Run tests and publish test coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -32,6 +38,8 @@ jobs:
           verbose: true
           
   publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description

Added condition `if: startsWith(github.ref, 'refs/tags/v')`  in publish job , so it will only trigger while publishing.

### Advantage 
We can get code coverage while pulling requests, as well as merging in master and it will not trigger publish job
