### PR TITLE
fix: correct MIME type detection for file uploads

### DIFF
--- a/src/main/java/com/razorpay/ApiUtils.java
+++ b/src/main/java/com/razorpay/ApiUtils.java
@@ -236,13 +236,22 @@ class ApiUtils {
     return trustManager;
   }
 
-  private static String getMediaType(String fileName){
+  static String getMediaType(String fileName) {
     int extensionIndex = fileName.lastIndexOf('.');
-    String extenionName = fileName.substring(extensionIndex + 1);
-    if(extenionName == "jpg" | extenionName == "jpeg" | extenionName == "png" | extenionName == "jfif"){
-      return "image/jpg";
+    if (extensionIndex < 0 || extensionIndex == fileName.length() - 1) {
+      return "application/octet-stream";
     }
-      return "image/pdf";
+    String extensionName = fileName.substring(extensionIndex + 1).toLowerCase();
+    if ("jpg".equals(extensionName) || "jpeg".equals(extensionName) || "jfif".equals(extensionName)) {
+      return "image/jpeg";
+    }
+    if ("png".equals(extensionName)) {
+      return "image/png";
+    }
+    if ("pdf".equals(extensionName)) {
+      return "application/pdf";
+    }
+    return "application/octet-stream";
   }
 
   private static RequestBody fileRequestBody(JSONObject requestObject){

--- a/src/test/java/com/razorpay/ApiUtilsTest.java
+++ b/src/test/java/com/razorpay/ApiUtilsTest.java
@@ -1,0 +1,53 @@
+package com.razorpay;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApiUtilsTest {
+
+  @Test
+  public void getMediaType_Jpg_ReturnsImageJpeg() {
+    assertEquals("image/jpeg", ApiUtils.getMediaType("document.jpg"));
+    assertEquals("image/jpeg", ApiUtils.getMediaType("doc.JPG"));
+  }
+
+  @Test
+  public void getMediaType_Jpeg_ReturnsImageJpeg() {
+    assertEquals("image/jpeg", ApiUtils.getMediaType("photo.jpeg"));
+    assertEquals("image/jpeg", ApiUtils.getMediaType("photo.JPEG"));
+  }
+
+  @Test
+  public void getMediaType_Png_ReturnsImagePng() {
+    assertEquals("image/png", ApiUtils.getMediaType("image.png"));
+    assertEquals("image/png", ApiUtils.getMediaType("image.PNG"));
+  }
+
+  @Test
+  public void getMediaType_Jfif_ReturnsImageJpeg() {
+    assertEquals("image/jpeg", ApiUtils.getMediaType("photo.jfif"));
+  }
+
+  @Test
+  public void getMediaType_Pdf_ReturnsApplicationPdf() {
+    assertEquals("application/pdf", ApiUtils.getMediaType("invoice.pdf"));
+    assertEquals("application/pdf", ApiUtils.getMediaType("report.PDF"));
+  }
+
+  @Test
+  public void getMediaType_UnknownExtension_ReturnsOctetStream() {
+    assertEquals("application/octet-stream", ApiUtils.getMediaType("file.xyz"));
+    assertEquals("application/octet-stream", ApiUtils.getMediaType("data.json"));
+  }
+
+  @Test
+  public void getMediaType_NoExtension_ReturnsOctetStream() {
+    assertEquals("application/octet-stream", ApiUtils.getMediaType("README"));
+  }
+
+  @Test
+  public void getMediaType_TrailingDot_ReturnsOctetStream() {
+    assertEquals("application/octet-stream", ApiUtils.getMediaType("file."));
+  }
+}


### PR DESCRIPTION
**Summary**
Fixes incorrect MIME type detection in ApiUtils.getMediaType() used for document uploads (account documents, stakeholder documents, dispute evidence).

**Problem**
getMediaType() was using reference equality (==) instead of value comparison for string matching of file extensions.
Because of this, extension checks failed and uploads defaulted to an incorrect MIME type (image/pdf), regardless of actual file type. This could lead to:
Incorrect Content-Type headers
Improper validation of non-PDF files
Unexpected API behavior for JPEG/PNG uploads

**Solution**
Replace reference equality (==) with .equals() for extension comparison
Fix variable typo: extenionName → extensionName
Correct MIME type mappings:
jpg, jpeg, jfif → image/jpeg
png → image/png
pdf → application/pdf

Add safe fallback to application/octet-stream for:
Unknown extensions
Missing extensions
Files with trailing dots

**Testing**
Added new unit test class: ApiUtilsTest
Covered:
All supported extensions
Case variations (JPG, Pdf, etc.)
Files without extension
Files with trailing dot
Unknown extensions

No changes to public API.
Behavior remains backward compatible except for corrected and standards-compliant MIME types.