### PR TITLE
Fix webhook signature verification for multi-byte payloads and add byte[] overload

### DIFF
--- a/src/main/java/com/razorpay/Utils.java
+++ b/src/main/java/com/razorpay/Utils.java
@@ -29,16 +29,16 @@ public class Utils {
     String payload = paymentId + '|' + subscriptionId;
     return verifySignature(payload, expectedSignature, apiSecret);
   }
-  
+
   public static boolean verifyPaymentLink(JSONObject attributes, String apiSecret)
-	      throws RazorpayException {
-	    String expectedSignature = attributes.getString("razorpay_signature");
-	    String paymentLinkStatus = attributes.getString("payment_link_status");
-	    String paymentLinkId = attributes.getString("payment_link_id");
-	    String paymentLinkRefId = attributes.getString("payment_link_reference_id");
-	    String paymentId = attributes.getString("razorpay_payment_id");
-	    String payload = paymentLinkId + '|' + paymentLinkRefId + '|' + paymentLinkStatus + '|' + paymentId;
-	    return verifySignature(payload, expectedSignature, apiSecret);
+      throws RazorpayException {
+    String expectedSignature = attributes.getString("razorpay_signature");
+    String paymentLinkStatus = attributes.getString("payment_link_status");
+    String paymentLinkId = attributes.getString("payment_link_id");
+    String paymentLinkRefId = attributes.getString("payment_link_reference_id");
+    String paymentId = attributes.getString("razorpay_payment_id");
+    String payload = paymentLinkId + '|' + paymentLinkRefId + '|' + paymentLinkStatus + '|' + paymentId;
+    return verifySignature(payload, expectedSignature, apiSecret);
   }
 
   public static boolean verifyWebhookSignature(String payload, String expectedSignature,
@@ -46,10 +46,23 @@ public class Utils {
     return verifySignature(payload, expectedSignature, webhookSecret);
   }
 
+  public static boolean verifyWebhookSignature(byte[] payload, String expectedSignature,
+      String webhookSecret) throws RazorpayException {
+    return verifySignature(payload, expectedSignature, webhookSecret);
+  }
+
   public static boolean verifySignature(String payload, String expectedSignature, String secret)
       throws RazorpayException {
     String actualSignature = getHash(payload, secret);
-    return isEqual(actualSignature.getBytes(), expectedSignature.getBytes());
+    return isEqual(actualSignature.getBytes(StandardCharsets.UTF_8),
+        expectedSignature.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public static boolean verifySignature(byte[] payload, String expectedSignature, String secret)
+      throws RazorpayException {
+    String actualSignature = getHash(payload, secret);
+    return isEqual(actualSignature.getBytes(StandardCharsets.UTF_8),
+        expectedSignature.getBytes(StandardCharsets.UTF_8));
   }
 
   public static String generateOnboardingSignature(JSONObject attributes, String secret) throws RazorpayException {
@@ -68,8 +81,7 @@ public class Utils {
       cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmSpec);
       byte[] encryptedData = cipher.doFinal(dataToEncrypt.getBytes(StandardCharsets.UTF_8));
       return bytesToHex(encryptedData);
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       throw new RazorpayException(e.getMessage());
     }
   }
@@ -87,12 +99,16 @@ public class Utils {
   }
 
   public static String getHash(String payload, String secret) throws RazorpayException {
+    return getHash(payload.getBytes(StandardCharsets.UTF_8), secret);
+  }
+
+  public static String getHash(byte[] payload, String secret) throws RazorpayException {
     Mac sha256_HMAC;
     try {
       sha256_HMAC = Mac.getInstance("HmacSHA256");
-      SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes("UTF-8"), "HmacSHA256");
+      SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
       sha256_HMAC.init(secret_key);
-      byte[] hash = sha256_HMAC.doFinal(payload.getBytes());
+      byte[] hash = sha256_HMAC.doFinal(payload);
       return new String(Hex.encodeHex(hash));
     } catch (Exception e) {
       throw new RazorpayException(e.getMessage());
@@ -100,7 +116,8 @@ public class Utils {
   }
 
   /**
-   * We are not using String.equals() method because of security issue mentioned in
+   * We are not using String.equals() method because of security issue mentioned
+   * in
    * <a href="http://security.stackexchange.com/a/83670">StackOverflow</a>
    * 
    * @param a

--- a/src/test/java/com/razorpay/UtilsTest.java
+++ b/src/test/java/com/razorpay/UtilsTest.java
@@ -14,10 +14,11 @@ public class UtilsTest {
 
     /**
      * Verify razorpay payment signature
+     * 
      * @throws RazorpayException
      */
     @Test
-    public void verifyPaymentSignature() throws RazorpayException{
+    public void verifyPaymentSignature() throws RazorpayException {
         JSONObject options = new JSONObject();
         options.put("razorpay_order_id", "order_IEIaMR65cu6nz3");
         options.put("razorpay_payment_id", "pay_IH4NVgf4Dreq1l");
@@ -28,10 +29,11 @@ public class UtilsTest {
 
     /**
      * Verify razorpay subscription
+     * 
      * @throws RazorpayException
      */
     @Test
-    public void verifySubscription() throws RazorpayException{
+    public void verifySubscription() throws RazorpayException {
         JSONObject options = new JSONObject();
         options.put("razorpay_subscription_id", "sub_ID6MOhgkcoHj9I");
         options.put("razorpay_payment_id", "pay_IDZNwZZFtnjyym");
@@ -42,10 +44,11 @@ public class UtilsTest {
 
     /**
      * Verify razorpay payment link signature
+     * 
      * @throws RazorpayException
      */
     @Test
-    public void verifyPaymentLink() throws RazorpayException{
+    public void verifyPaymentLink() throws RazorpayException {
         JSONObject options = new JSONObject();
         options.put("payment_link_reference_id", "TSsd1989");
         options.put("razorpay_payment_id", "pay_IH3d0ara9bSsjQ");
@@ -58,14 +61,15 @@ public class UtilsTest {
 
     /**
      * Verify razorpay webhook signature
+     * 
      * @throws RazorpayException
      */
     @Test
-    public void verifyWebhookSignature() throws RazorpayException{
+    public void verifyWebhookSignature() throws RazorpayException {
         String signature = "2fe04e22977002e6c7cb553adab8b460cb9e2a4970d5953cb27a8472752e3bbc";
         String payload = "{\"a\":1,\"b\":2,\"c\":{\"d\":3}}";
         String secret = "123456";
-        assertTrue(Utils.verifyWebhookSignature(payload,signature, secret));
+        assertTrue(Utils.verifyWebhookSignature(payload, signature, secret));
     }
 
     @Test
@@ -86,10 +90,42 @@ public class UtilsTest {
         }
     }
 
+    @Test
+    public void verifyWebhookSignatureUtf8Payload() throws Exception {
+        String payload = "{\"name\":\"café ₹ 😄\",\"notes\":\"हेलो\"}";
+        String secret = "123456";
+
+        String signature = computeWebhookSignature(payload, secret);
+
+        assertTrue(Utils.verifyWebhookSignature(payload, signature, secret));
+        assertTrue(Utils.verifyWebhookSignature(payload.getBytes(StandardCharsets.UTF_8), signature, secret));
+    }
+
+    private String computeWebhookSignature(String payload, String secret) throws Exception {
+        javax.crypto.Mac sha256_HMAC = javax.crypto.Mac.getInstance("HmacSHA256");
+        SecretKeySpec secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        sha256_HMAC.init(secretKey);
+        byte[] hash = sha256_HMAC.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        return bytesToHex(hash);
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+
     private String decryptData(String encryptedHexData, String secret) throws Exception {
         byte[] encryptedData = hexStringToByteArray(encryptedHexData);
         return decrypt(encryptedData, secret);
     }
+
     public static String decrypt(byte[] encryptedData, String secret) throws Exception {
         byte[] keyBytes = secret.substring(0, 16).getBytes(StandardCharsets.UTF_8);
         SecretKeySpec keySpec = new SecretKeySpec(keyBytes, "AES");
@@ -107,7 +143,7 @@ public class UtilsTest {
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
             data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                    + Character.digit(s.charAt(i+1), 16));
+                    + Character.digit(s.charAt(i + 1), 16));
         }
         return data;
     }


### PR DESCRIPTION
Fixes #351

## Problem
Webhook signature verification could fail for payloads containing special or multi-byte characters due to use of platform default charset.

## Fix
- Use UTF-8 encoding explicitly for hashing
- Add overloaded method to accept raw byte[] payload for safer verification

## Changes
- Added verifyWebhookSignature(byte[] payload, ...)
- Updated hashing logic to use StandardCharsets.UTF_8
- Ensured backward compatibility by delegating the String-based method to the byte[] implementation

## Tests
- Added test case with UTF-8 payload (emoji and multi-byte characters)
- Verified using:
  mvn -Dtest=UtilsTest test

## Notes
- This change is backward compatible
- Full test suite failures are due to existing Mockito + OkHttp mocking issues unrelated to this change