### PR TITLE
chore: upgrade to Java 11+ and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,52 +8,55 @@ on:
   pull_request:
     branches:
       - master
-# Jobs
 jobs:
   test:
-    name: Run tests and publish test coverage
+    name: Test on Java ${{ matrix.java-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [11, 17, 21]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Set up Java JDK
-        uses: actions/setup-java@v2
+      - name: Set up Java JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
-          distribution: 'adopt'
-             
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+
       - name: Install dependencies
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dgpg.skip
-           
+
       - name: Run tests and collect coverage
-        run: mvn -B test 
+        run: mvn -B test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        if: matrix.java-version == 21
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true
-          
+
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          java-version: 8
-          distribution: 'adopt'
+          java-version: 11
+          distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-        
+
       - name: Build with Maven
         run: mvn clean package -B
-        
+
       - name: Publish package
         run: |
             mvn deploy -Dgpg.passphrase=${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     <!-- https://mvnrepository.com/artifact/org.springframework/spring-core -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>5.2.0</version>
+      <artifactId>mockito-core</artifactId>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>2.13.0</version>
+      <version>5.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -68,31 +68,31 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.10.0</version>
+      <version>4.12.0</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>logging-interceptor</artifactId>
-      <version>3.10.0</version>
+      <version>4.12.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20231013</version>
+      <version>20240303</version>
     </dependency>
 
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.11</version>
+      <version>1.17.1</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.3</version>
+      <version>1.12.0</version>
     </dependency>
 
   </dependencies>

--- a/src/test/java/com/razorpay/BaseTest.java
+++ b/src/test/java/com/razorpay/BaseTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +30,7 @@ public class BaseTest {
     @Before
     public void setUp() throws Exception {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         mockGetCall();
         mockURL(Collections.emptyList());
     }
@@ -44,7 +44,7 @@ public class BaseTest {
 
         Call call = mock(Call.class);
         when(call.execute()).thenReturn(mockedResponse);
-        when(okHttpClient.newCall(anyObject())).thenReturn(call);
+        when(okHttpClient.newCall(any())).thenReturn(call);
 
     }
 


### PR DESCRIPTION
## Summary
- Upgrade minimum Java version from 8 to 11
- Update GitHub Actions from v2 to v4 with temurin distribution
- Add CI matrix testing for Java 11, 17, 21
- Update dependencies to latest versions:
  - **OkHttp 3.10.0 → 4.12.0** (major version - OkHttp 4 is Kotlin-based with API changes, tests confirm compatibility)
  - mockito-inline 2.13.0 → mockito-core 5.23.0 (inline merged into core in Mockito 5)
  - commons-codec 1.11 → 1.17.1
  - commons-text 1.3 → 1.12.0 (**security fix for CVE-2022-42889 Text4Shell RCE**)
  - org.json 20231013 → 20240303
- Fix deprecated Mockito APIs (anyObject→any, initMocks→openMocks)

## Breaking Changes
- Minimum Java version raised from 8 to 11
- OkHttp upgraded from 3.x to 4.x (Kotlin-based, API compatible based on passing tests)

## Test plan
- [x] CI passes on Java 11, 17, 21
- [x] Existing tests continue to pass
- [x] OkHttp 4 compatibility verified via test suite

🤖 Generated with [Claude Code](https://claude.ai/code)