### PR TITLE
fix: update Gradle dependency version to 1.4.9 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-implementation "com.razorpay:razorpay-java:1.4.7"
+implementation "com.razorpay:razorpay-java:1.4.9"
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Updated the Gradle users dependency version in README.md from `1.4.7` to `1.4.9`
- The Maven section was updated in the version bump PR but the Gradle section was missed

## Test plan
- [ ] Verify Gradle snippet in README.md shows `1.4.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)